### PR TITLE
Better log file parsing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{36},flake8
+envlist=py{38},lint
 skipsdist=True
 
 [testenv]
@@ -7,9 +7,9 @@ commands=python -m unittest discover tests
 deps=-r {toxinidir}/requirements.txt
 
 basepython=
-    py36: python3.6
+    py38: python3.8
 
-[testenv:flake8]
-basepython=python3.6
-deps=flake8>=2.2.0
-commands=flake8 fetch.py tests
+[testenv:lint]
+basepython=python3.8
+deps=black
+commands=black --check fetch.py tests


### PR DESCRIPTION
Simplify the method used to parse Apache log files so that it is more robust to exceptional formats. The current code has problems if the user agent string contains quotation marks.